### PR TITLE
Use os_cloud_config in k5_auth

### DIFF
--- a/Examples/clouds.yml
+++ b/Examples/clouds.yml
@@ -1,0 +1,36 @@
+---
+# Note many of these details are stored in secure.yml as per
+# https://docs.openstack.org/developer/os-client-config/
+# The name of the cloud must match in secure.y(a)ml
+
+clouds:
+  k5_project_a:
+    identity_api_version: 3
+    auth:
+      auth_url: https://identity.uk-1.cloud.global.fujitsu.com/v3
+
+    # If you use multiple regions, list them here. If you don't specify which
+    # region to use when you specify which cloud to use, for example:
+    #
+    # ANSIBLE PLAYBOOK EXAMPLE
+    # - k5_auth:
+    #     cloud: k5_project_a
+    #     region: uk-1            # IF YOU OMIT THIS
+    # openstack --os-cloud k5_project_a --os-region de-1 server list
+    #
+    # then it will use the first region specified here.
+
+    regions:
+      - uk-1
+      - de-1
+      - fi-1
+      - jp-east-1
+      - jp-west-1
+      - jp-west-2
+
+  k5_project_b:
+    identity_api_version: 3
+    # Alternatively, if you only ever use a single region, use this format:
+    region_name: uk-1
+    auth:
+      auth_url: https://identity.uk-1.cloud.global.fujitsu.com/v3

--- a/Examples/secure.yml.example
+++ b/Examples/secure.yml.example
@@ -1,0 +1,35 @@
+---
+clouds:
+  k5_project_a:
+    # Go to the "Manage" -> "Project" page it will bring up an
+    # error message. Click through to see the details
+    # and this is where the domain ID is... or just ask the PMO
+    default_domain: decafbaddecafbad1234567890badbad
+    auth:
+      # Get this from the "API Access" tab on the "Access and
+      # Security" page. It's the suffix of many of the API
+      # endpoints - e.g. orchestration, blockstorage
+      project_id: decafbaddecafbad1234567890badbad
+      # This is the name of the project you're applying this
+      # against
+      project_name: project_a
+      # These are the "Real" credentials you've been supplied
+      # from the PMO
+      username: bloggsf
+      # This is the password you've received from K5. Note, you
+      # will have to change this each time you change your K5
+      # password!
+      password: decafbaddecafbad1234567890badbad
+      # This is the name of the "Contract" you log into.
+      user_domain_name: contract_number
+
+  k5_project_b:
+    # As far as I can see right now, you need to repeat this
+    # each project.
+    default_domain: decafbaddecafbad1234567890badbad
+    auth:
+      password: decafbaddecafbad1234567890badbad
+      project_id: decafbaddecafbad1234567890badbad
+      project_name: project_b
+      username: bloggsf
+      user_domain_name: contract_number

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ Or use the parameters in ```k5_auth```.
  export OS_USER_DOMAIN_NAME=contract id
 ```
 
+### clouds.y(a)ml / secure.y(a)ml
+See the example files in Examples/clouds.yml and Examples/secure.yml.example
+
 # Contributors
 
 Many thanks to the following people:


### PR DESCRIPTION
This permits the use of clouds.yml in k5_auth and also means you can use
the same in os_* modules.

Functionality between k5_auth prior to this commit, using an openrc file
or passing parameters to the k5_auth module, have not changed.