### PR TITLE
Change policies param handling to be K5-compatible

### DIFF
--- a/k5_server_group.py
+++ b/k5_server_group.py
@@ -235,7 +235,7 @@ def main():
     module = AnsibleModule( argument_spec=dict(
         state = dict(choices=['list', 'present', 'absent' ], default='list'),
         name = dict(default=None, type='str'), 
-        policies = dict(choices=[['affinity'], ['anti-affinity']], default=None, type='list'), 
+        policies = dict(required=False, type='list'),
         availability_zone = dict(default=None, type='str'), 
         k5_auth = dict(required=True,default=None, type='dict')
     ),

--- a/k5_server_group.py
+++ b/k5_server_group.py
@@ -235,7 +235,7 @@ def main():
     module = AnsibleModule( argument_spec=dict(
         state = dict(choices=['list', 'present', 'absent' ], default='list'),
         name = dict(default=None, type='str'), 
-        policies = dict(required=False, type='list'),
+        policies = dict(choices=['affinity', 'anti-affinity'], default=None, type='list'),
         availability_zone = dict(default=None, type='str'), 
         k5_auth = dict(required=True,default=None, type='dict')
     ),


### PR DESCRIPTION
This change resolves the issue of specifying a policy returning an error:
"value of policies must be one or more of: ['affinity'], ['anti-affinity']. Got no match for: anti-affinity"